### PR TITLE
Fix wrong aws static credentials usage

### DIFF
--- a/src/aws/s3.go
+++ b/src/aws/s3.go
@@ -22,7 +22,7 @@ var (
 
 func NewS3(ctx global.Context) global.AwsS3 {
 	sess, err := session.NewSession(&aws.Config{
-		Credentials: credentials.NewStaticCredentials("", ctx.Config().Aws.SecretKey, ctx.Config().Aws.SessionToken),
+		Credentials: credentials.NewStaticCredentials(ctx.Config().Aws.AccessToken, ctx.Config().Aws.SecretKey, ""),
 		Region:      aws.String(ctx.Config().Aws.Region),
 	})
 	if err != nil {

--- a/src/configure/config.go
+++ b/src/configure/config.go
@@ -63,9 +63,9 @@ type Config struct {
 
 	// Aws
 	Aws struct {
-		SessionToken string `json:"session_token,omitempty" mapstructure:"session_token,omitempty"`
-		SecretKey    string `json:"secret_key,omitempty" mapstructure:"secret_key,omitempty"`
-		Region       string `json:"region,omitempty" mapstructure:"region,omitempty"`
+		AccessToken string `json:"access_token,omitempty" mapstructure:"access_token,omitempty"`
+		SecretKey   string `json:"secret_key,omitempty" mapstructure:"secret_key,omitempty"`
+		Region      string `json:"region,omitempty" mapstructure:"region,omitempty"`
 	} `json:"aws,omitempty" mapstructure:"aws,omitempty"`
 
 	Rmq struct {


### PR DESCRIPTION
The current setup did not authenticate to AWS via the standard access token+secret key, as the parameters were used wrongly.